### PR TITLE
Initial commit from the logstash-output-slack repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.gem
+Gemfile.lock
+.ruby-version
+.bundle
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ Gemfile.lock
 .ruby-version
 .bundle
 vendor
+lib/com
+lib/logstash-output-slack_jars.rb
+lib/org

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+cache: bundler
+rvm:
+  - jruby-17mode # JRuby in 1.7 mode
+  - jruby-18mode # JRuby in 1.8 mode
+  - jruby-19mode # JRuby in 1.9 mode
+  - jruby-head
+
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+  - openjdk6
+
+script: bundle exec rspec spec
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 cache: bundler
 rvm:
+  - jruby 1.7.21
   - jruby-head
 
 jdk:
+  - openjdk6
   - openjdk7
   - oraclejdk7
   - oraclejdk8
@@ -12,3 +14,11 @@ script: bundle exec rspec spec
 
 notifications:
   email: false
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: jruby-head
+  exclude:
+    - rvm: jruby-head
+      jdk: openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ notifications:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: jruby-head
   exclude:
     - rvm: jruby-head
       jdk: openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: ruby
 cache: bundler
 rvm:
+  - jruby-1.7.19
+  - jruby 1.7.22
   - jruby-head
 
 jdk:
+  - openjdk6
   - openjdk7
   - oraclejdk7
   - oraclejdk8
@@ -12,3 +15,8 @@ script: bundle exec rspec spec
 
 notifications:
   email: false
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: ruby
 cache: bundler
 rvm:
-  - jruby-17mode # JRuby in 1.7 mode
-  - jruby-18mode # JRuby in 1.8 mode
-  - jruby-19mode # JRuby in 1.9 mode
   - jruby-head
 
 jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
-  - openjdk6
 
 script: bundle exec rspec spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.19
-  - jruby 1.7.22
+  - jruby 1.7.21
   - jruby-head
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ matrix:
     - rvm: jruby-head
   exclude:
     - rvm: jruby-head
-      jdk: openjkd6
+      jdk: openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: jruby-head
+  exclude:
+    - rvm: jruby-head
+      jdk: openjkd6

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-gem "logstash", :github => "elasticsearch/logstash", :branch => "1.5"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gemspec
+gem "logstash", :github => "elasticsearch/logstash", :branch => "1.5"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/cyli/logstash-output-slack.svg?branch=master)](https://travis-ci.org/cyli/logstash-output-slack)
 
+=======
 
 # Logstash Slack Output Plugin
 
@@ -39,6 +40,16 @@ output {
 
 Not supported yet: attachments
 
+## Changelog:
+- [v0.1.1](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.1):
+    - Added variable expansion to usernames and channel names ([#6](https://github.com/cyli/logstash-output-slack/pull/6))
+    - Fixed bug when reporting malformed requests ([#3](https://github.com/cyli/logstash-output-slack/pull/3))
+    - Test fixes since newer versions of logstash-core expects the values in
+        the `add_field` hash to not be integers.
+- [v0.1.0](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.0):
+    - initial version containing basic slack functionality
+
+
 ## Developing
 
 ### 1. Plugin Developement and Testing
@@ -67,23 +78,23 @@ bundle install
 bundle exec rspec
 ```
 
-### Installation on Logstash >= 1.5
+## Installation on Logstash >= 1.5
 
-In the logstash directory, run:  `bin/plugin install logstash-output-slack`
+In the logstash directory, run:  `bin/plugin install logstash-output-slack`, which will download and install the public gem.
 
 #### To build your own gem and install:
 
 1. `git clone <thisrepo>`
 1. `bundle install`
 1. `gem build logstash-output-slack.gemspec`
+1. `cd <path to logstash>`
+1. `logstash>1.5.0`: `bin/plugin install <path-to-your-built-gem>`
 
-You should just be able to do `bin/plugin install <path-to-your-built-gem>`, but due to [this bug](https://github.com/elastic/logstash/issues/2674) installing from a local gem doesn't work right now.
+    On `logstash==1.5.0`, due to [this bug](https://github.com/elastic/logstash/issues/2674), installing from a local gem doesn't work. You will need to:
 
-You need to:
-
-1. Make sure that the `logstash-core` gem you've installed matches the exact beta 1.5 logstash version you are running.
-1. modify the logstash Gemfile to include the line `gem "logstash-output-slack", :path => <path_to_the_directory_your_gem_is_in>`
-1. `bin/plugin install --no-verify`
+    1. Make sure that the `logstash-core` gem you've installed matches the exact beta 1.5 logstash version you are running.
+    1. modify the logstash Gemfile to include the line `gem "logstash-output-slack", :path => <path_to_the_directory_your_gem_is_in>`
+    1. `bin/plugin install --no-verify`
 
 #### Verify that the plugin installed correctly
 `bin/plugin list | grep logstash-output-slack`
@@ -97,7 +108,7 @@ output { slack { <your slack config here> }}'
 
 And type some text in.  The same text should appear in the channel it's configured to go in.
 
-### Installation on Logstash < 1.4
+### Installation on Logstash < 1.5
 
 Gem-installing this plugin would only work on Logstash 1.5.  For Logstash < 1.5, you could just rename `lib` in this repo to `logstash`, and then run Logstash with `--pluginpath <path_to_this_repo>.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+## Logstash Slack Output Plugin
+
+This is currently in alpha as I figure out how to write plugins. :)

--- a/README.md
+++ b/README.md
@@ -32,23 +32,32 @@ output {
 
 Not supported yet: attachments
 
+### Changelog:
+- v 0.1.1:
+    - Added variable expansion to usernames and channel names ([#6](https://github.com/cyli/logstash-output-slack/pull/6))
+    - Fixed bug when reporting malformed requests ([#3](https://github.com/cyli/logstash-output-slack/pull/3))
+    - Test fixes since newer versions of logstash-core expects the values in
+        the `add_field` hash to not be integers.
+- v 0.1.0:
+    - initial version containing basic slack functionality
+
 ### Installation on Logstash >= 1.5
 
-In the logstash directory, run:  `bin/plugin install logstash-output-slack`
+In the logstash directory, run:  `bin/plugin install logstash-output-slack`, which will download and install the public gem.
 
 #### To build your own gem and install:
 
 1. `git clone <thisrepo>`
 1. `bundle install`
 1. `gem build logstash-output-slack.gemspec`
+1. `cd <path to logstash>`
+1. `logstash>1.5.0`: `bin/plugin install <path-to-your-built-gem>`
 
-You should just be able to do `bin/plugin install <path-to-your-built-gem>`, but due to [this bug](https://github.com/elastic/logstash/issues/2674) installing from a local gem doesn't work right now.
+    On `logstash==1.5.0`, due to [this bug](https://github.com/elastic/logstash/issues/2674), installing from a local gem doesn't work right now. You will need to:
 
-You need to:
-
-1. Make sure that the `logstash-core` gem you've installed matches the exact beta 1.5 logstash version you are running.
-1. modify the logstash Gemfile to include the line `gem "logstash-output-slack", :path => <path_to_the_directory_your_gem_is_in>`
-1. `bin/plugin install --no-verify`
+    1. Make sure that the `logstash-core` gem you've installed matches the exact beta 1.5 logstash version you are running.
+    1. modify the logstash Gemfile to include the line `gem "logstash-output-slack", :path => <path_to_the_directory_your_gem_is_in>`
+    1. `bin/plugin install --no-verify`
 
 #### Verify that the plugin installed correctly
 `bin/plugin list | grep logstash-output-slack`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/cyli/logstash-output-slack.svg)](https://travis-ci.org/cyli/logstash-output-slack)
+
 ## Logstash Slack Output Plugin
 
 This is currently in alpha as I figure out how to write plugins. :)

--- a/README.md
+++ b/README.md
@@ -21,18 +21,19 @@ output {
     ...
     slack {
         url => <YOUR SLACK WEBHOOK URL HERE>
-        channel => [channel-name - this is optional]
-        username => [slack username - this is optional]
+        channel => [channel-name - optional]
+        username => [slack username - optional]
         icon_emoji => [emoji, something like ":simple_smile:" - optional]
         icon_url => [icon url, would be overriden by icon_emoji - optional]
         format => [default is "%{message}", but used to format the text - optional]
+        attachments => [an array of attachment maps as specified by the slack API - optional; if there is an "attachments" field in the event map and it is valid, it will override what is configured here, even if it's empty]
     }
 }
 ```
 
-Not supported yet: attachments
-
 ### Changelog:
+- [v0.1.2](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.2):
+    - Added support for attachments
 - [v0.1.1](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.1):
     - Added variable expansion to usernames and channel names ([#6](https://github.com/cyli/logstash-output-slack/pull/6))
     - Fixed bug when reporting malformed requests ([#3](https://github.com/cyli/logstash-output-slack/pull/3))

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ output {
 Not supported yet: attachments
 
 ### Changelog:
-- v 0.1.1:
+- [v0.1.1](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.1):
     - Added variable expansion to usernames and channel names ([#6](https://github.com/cyli/logstash-output-slack/pull/6))
     - Fixed bug when reporting malformed requests ([#3](https://github.com/cyli/logstash-output-slack/pull/3))
     - Test fixes since newer versions of logstash-core expects the values in
         the `add_field` hash to not be integers.
-- v 0.1.0:
+- [v0.1.0](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.0):
     - initial version containing basic slack functionality
 
 ### Installation on Logstash >= 1.5
@@ -53,7 +53,7 @@ In the logstash directory, run:  `bin/plugin install logstash-output-slack`, whi
 1. `cd <path to logstash>`
 1. `logstash>1.5.0`: `bin/plugin install <path-to-your-built-gem>`
 
-    On `logstash==1.5.0`, due to [this bug](https://github.com/elastic/logstash/issues/2674), installing from a local gem doesn't work right now. You will need to:
+    On `logstash==1.5.0`, due to [this bug](https://github.com/elastic/logstash/issues/2674), installing from a local gem doesn't work. You will need to:
 
     1. Make sure that the `logstash-core` gem you've installed matches the exact beta 1.5 logstash version you are running.
     1. modify the logstash Gemfile to include the line `gem "logstash-output-slack", :path => <path_to_the_directory_your_gem_is_in>`
@@ -71,7 +71,7 @@ output { slack { <your slack config here> }}'
 
 And type some text in.  The same text should appear in the channel it's configured to go in.
 
-### Installation on Logstash < 1.4
+### Installation on Logstash < 1.5
 
 Gem-installing this plugin would only work on Logstash 1.5.  For Logstash < 1.5, you could just rename `lib` in this repo to `logstash`, and then run Logstash with `--pluginpath <path_to_this_repo>.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/cyli/logstash-output-slack.svg)](https://travis-ci.org/cyli/logstash-output-slack)
+[![Build Status](https://travis-ci.org/cyli/logstash-output-slack.svg?branch=master)](https://travis-ci.org/cyli/logstash-output-slack)
 
 ## Logstash Slack Output Plugin
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/cyli/logstash-output-slack.svg?branch=master)](https://travis-ci.org/cyli/logstash-output-slack)
 
+Reviews of the code/contributions are very welcome (particularly with testing!), since I don't really know Ruby.
+
 ## Logstash Slack Output Plugin
 
 Uses Slack [incoming webhooks API](https://api.slack.com/incoming-webhooks) to send log events to Slack.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,66 @@
 
 ## Logstash Slack Output Plugin
 
-This is currently in alpha as I figure out how to write plugins. :)
+Uses Slack [incoming webhooks API](https://api.slack.com/incoming-webhooks) to send log events to Slack.
+
+Usage:
+
+```
+input {
+    ...
+}
+
+filters {
+    ...
+}
+
+output {
+    ...
+    slack {
+        url => <YOUR SLACK WEBHOOK URL HERE>
+        channel => [channel-name - this is optional]
+        username => [slack username - this is optional]
+        icon_emoji => [emoji, something like ":simple_smile:" - optional]
+        icon_url => [icon url, would be overriden by icon_emoji - optional]
+        format => [default is "%{message}", but used to format the text - optional]
+    }
+}
+```
+
+Not supported yet: attachments
+
+### Installation on Logstash >= 1.5
+
+In the logstash directory, run:  `bin/plugin install logstash-output-slack`
+
+#### To build your own gem and install:
+
+1. `git clone <thisrepo>`
+1. `bundle install`
+1. `gem build logstash-output-slack.gemspec`
+
+You should just be able to do `bin/plugin install <path-to-your-built-gem>`, but due to [this bug](https://github.com/elastic/logstash/issues/2674) installing from a local gem doesn't work right now.
+
+You need to:
+
+1. Make sure that the `logstash-core` gem you've installed matches the exact beta 1.5 logstash version you are running.
+1. modify the logstash Gemfile to include the line `gem "logstash-output-slack", :path => <path_to_the_directory_your_gem_is_in>`
+1. `bin/plugin install --no-verify`
+
+#### Verify that the plugin installed correctly
+`bin/plugin list | grep logstash-output-slack`
+
+#### Test that it works:
+```
+bin/logstash -e '
+input { stdin {} }
+output { slack { <your slack config here> }}'
+```
+
+And type some text in.  The same text should appear in the channel it's configured to go in.
+
+### Installation on Logstash < 1.4
+
+Gem-installing this plugin would only work on Logstash 1.5.  For Logstash < 1.5, you could just rename `lib` in this repo to `logstash`, and then run Logstash with `--pluginpath <path_to_this_repo>.
+
+See the [flags](http://logstash.net/docs/1.4.2/flags) documentation for Logstash 1.4.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 [![Build Status](https://travis-ci.org/cyli/logstash-output-slack.svg?branch=master)](https://travis-ci.org/cyli/logstash-output-slack)
 
-## Logstash Slack Output Plugin
 
-Uses Slack [incoming webhooks API](https://api.slack.com/incoming-webhooks) to send log events to Slack.
+# Logstash Slack Output Plugin
 
-Usage:
+This is a plugin for [Logstash](https://github.com/elasticsearch/logstash) that pushes log events to [Slack](www.slack.com) using their [incoming webhooks API](https://api.slack.com/incoming-webhooks).
+
+It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
+
+to send log events to Slack.
+
+## Need Help?
+
+Need help? Try #logstash on freenode IRC or the logstash-users@googlegroups.com mailing list.
+
+## Usage
 
 ```
 input {
@@ -29,6 +38,34 @@ output {
 ```
 
 Not supported yet: attachments
+
+## Developing
+
+### 1. Plugin Developement and Testing
+
+#### Code
+- To get started, you'll need JRuby with the Bundler gem installed.
+
+- Create a new plugin or clone and existing from the GitHub [logstash-plugins](https://github.com/logstash-plugins) organization. We also provide [example plugins](https://github.com/logstash-plugins?query=example).
+
+- Install dependencies
+```sh
+bundle install
+```
+
+#### Test
+
+- Update your dependencies
+
+```sh
+bundle install
+```
+
+- Run tests
+
+```sh
+bundle exec rspec
+```
 
 ### Installation on Logstash >= 1.5
 
@@ -65,3 +102,13 @@ And type some text in.  The same text should appear in the channel it's configur
 Gem-installing this plugin would only work on Logstash 1.5.  For Logstash < 1.5, you could just rename `lib` in this repo to `logstash`, and then run Logstash with `--pluginpath <path_to_this_repo>.
 
 See the [flags](http://logstash.net/docs/1.4.2/flags) documentation for Logstash 1.4.
+
+## Contributing
+
+All contributions are welcome: ideas, patches, documentation, bug reports, complaints, and even something you drew up on a napkin.
+
+Programming is not a required skill. Whatever you've seen about open source and maintainers or community members  saying "send patches or die" - you will not see that here.
+
+It is more important to the community that you are able to contribute.
+
+For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md) file.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+@files=[]
+
+task :default do
+  system("rake -T")
+end
+
+require "logstash/devutils/rake"

--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -1,0 +1,77 @@
+# encoding: utf-8
+require "logstash/outputs/base"
+require "logstash/namespace"
+
+class LogStash::Outputs::Slack < LogStash::Outputs::Base
+  config_name "slack"
+  milestone 1
+
+  # The incoming webhook URI needed to post a message
+  config :url, :validate => :string, :required => true
+
+  # The text to post in slack
+  config :format, :validate => :string, :default => "%{message}"
+
+  # The channel to post to
+  config :channel, :validate => :string
+
+  # The username to use for posting
+  config :username, :validate => :string
+
+  # Emoji icon to use
+  config :icon_emoji, :validate => :string
+
+  # Icon URL to use
+  config :icon_url, :validate => :string
+
+
+  public
+  def register
+    require 'ftw'
+    require 'cgi'
+    require 'json'
+
+    @agent = FTW::Agent.new
+
+    @content_type = "application/x-www-form-urlencoded"
+  end # def register
+
+  public
+  def receive(event)
+    return unless output?(event)
+
+    payload_json = Hash.new
+    payload_json['text'] = event.sprintf(@format)
+
+    if not @channel.nil?
+      payload_json['channel'] = @channel
+    end
+
+    if not @username.nil?
+      payload_json['username'] = @username
+    end
+
+    if not @icon_emoji.nil?
+      payload_json['icon_emoji'] = @icon_emoji
+    elsif not @icon_url.nil?
+      payload_json['icon_url'] = @icon_url
+    end
+
+    begin
+      request = @agent.post(@url)
+      request["Content-Type"] = @content_type
+      request.body = "payload=#{CGI.escape(JSON.dump(payload_json))}"
+
+      response = @agent.execute(request)
+
+      # Consume body to let this connection be reused
+      rbody = ""
+      response.read_body { |c| rbody << c }
+      #puts rbody
+    rescue Exception => e
+      @logger.warn("Unhandled exception", :request => request,
+                   :response => response, :exception => e,
+                   :stacktrace => e.backtrace)
+    end
+  end # def receive
+end # class LogStash::Outputs::Slack

--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -42,11 +42,11 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
     payload_json['text'] = event.sprintf(@format)
 
     if not @channel.nil?
-      payload_json['channel'] = @channel
+      payload_json['channel'] = event.sprintf(@channel)
     end
 
     if not @username.nil?
-      payload_json['username'] = @username
+      payload_json['username'] = event.sprintf(@username)
     end
 
     if not @icon_emoji.nil?
@@ -66,7 +66,7 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
         :'User-Agent' => "logstash-output-slack",
         :content_type => @content_type) { |response, request, result, &block|
           if response.code != 200
-            @logger.warn("Got a #{response.code} result: " + result)
+            @logger.warn("Got a #{response.code} response: #{response}")
           end
         }
     rescue Exception => e

--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -24,6 +24,9 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
   # Icon URL to use
   config :icon_url, :validate => :string
 
+  # Attachments array as described https://api.slack.com/docs/attachments
+  config :attachments, :validate => :array
+
 
   public
   def register
@@ -55,6 +58,10 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
       payload_json['icon_emoji'] = @icon_emoji
     elsif not @icon_url.nil?
       payload_json['icon_url'] = @icon_url
+    end
+
+    if not @attachments.nil?
+      payload_json['attachments'] = @attachments
     end
 
     begin

--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -42,11 +42,11 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
     payload_json['text'] = event.sprintf(@format)
 
     if not @channel.nil?
-      payload_json['channel'] = @channel
+      payload_json['channel'] = event.sprintf(@channel)
     end
 
     if not @username.nil?
-      payload_json['username'] = @username
+      payload_json['username'] = event.sprintf(@username)
     end
 
     if not @icon_emoji.nil?

--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -66,7 +66,7 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
         :'User-Agent' => "logstash-output-slack",
         :content_type => @content_type) { |response, request, result, &block|
           if response.code != 200
-            @logger.warn("Got a #{response.code} result: " + result)
+            @logger.warn("Got a #{response.code} response: #{response}")
           end
         }
     rescue Exception => e

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -1,0 +1,23 @@
+Gem::Specification.new do |s|
+  s.name            = 'logstash-output-slack'
+  s.version         = '0.0.0'
+  s.licenses        = ['MIT']
+  s.summary         = "Write events to Slack"
+  s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
+  s.authors         = ["Ying Li"]
+  s.email           = 'cyli@twistedmatrix.com'
+  s.require_paths   = ["lib"]
+
+  # Files
+  s.files = `git ls-files`.split($\)
+
+  # Tests
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+
+  # Special flag to let us know this is actually a logstash plugin
+  s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
+
+  # Gem dependencies
+  s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
+  s.add_development_dependency 'logstash-devutils'
+end

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-slack'
-  s.version         = '0.1.1'
+  s.version         = '0.1.2'
   s.licenses        = ['MIT','Apache License (2.0)']
   s.summary         = "Write events to Slack"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-slack'
-  s.version         = '0.1.2'
+  s.version         = '0.1.3'
   s.licenses        = ['MIT','Apache License (2.0)']
   s.summary         = "Write events to Slack"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-slack'
-  s.version         = '0.1.0'
+  s.version         = '0.1.1'
   s.licenses        = ['MIT','Apache License (2.0)']
   s.summary         = "Write events to Slack"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-codec-plain"
   s.add_runtime_dependency "rest-client"
   s.add_development_dependency "logstash-devutils"
+  s.add_development_dependency "logstash-filter-json"
   s.add_development_dependency "logstash-input-generator"
   s.add_development_dependency "webmock"
 

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-slack'
-  s.version         = '0.0.0'
-  s.licenses        = ['MIT']
+  s.version         = '0.1.0'
+  s.licenses        = ['MIT','Apache License (2.0)']
   s.summary         = "Write events to Slack"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Ying Li"]
@@ -18,6 +18,14 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
-  s.add_development_dependency 'logstash-devutils'
+  s.add_runtime_dependency "logstash-core", ">= 1.4.0", "< 2.0.0"
+  s.add_runtime_dependency "logstash-codec-plain"
+  s.add_runtime_dependency "rest-client"
+  s.add_development_dependency "logstash-devutils"
+  s.add_development_dependency "logstash-input-generator"
+  s.add_development_dependency "webmock"
+
+  # Jar dependencies
+  s.requirements << "jar 'org.elasticsearch:elasticsearch', '1.4.0'"
+  s.add_runtime_dependency "jar-dependencies", ">= 0.1.7"
 end

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -5,7 +5,8 @@ Gem::Specification.new do |s|
   s.summary         = "Write events to Slack"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Ying Li"]
-  s.email           = 'cyli@twistedmatrix.com'
+  s.email           = 'cyli@ying.com'
+  s.homepage        = "https://github.com/cyli/logstash-output-slack"
   s.require_paths   = ["lib"]
 
   # Files
@@ -18,15 +19,21 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 1.4.0", "< 2.0.0"
-  s.add_runtime_dependency "logstash-codec-plain"
-  s.add_runtime_dependency "rest-client"
-  s.add_development_dependency "logstash-devutils"
-  s.add_development_dependency "logstash-filter-json"
-  s.add_development_dependency "logstash-input-generator"
-  s.add_development_dependency "webmock"
+  if JRUBY_VERSION < "1.8"
+    s.add_runtime_dependency "logstash-core", "<= 2.0.0.snapshot3", ">= 1.4.0"
+  else
+    s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot3", ">= 1.4.0"
+  end
+
+  s.add_runtime_dependency "logstash-codec-plain", "~> 2.0.0", ">= 1.0.0"
+  s.add_runtime_dependency "rest-client", '~> 1.8', ">= 1.8.0"
+  s.add_development_dependency "logstash-devutils", "~> 0.0.16"
+  s.add_development_dependency "logstash-filter-json", "~> 2.0.1", ">= 1.0.1"
+  s.add_development_dependency "logstash-input-generator", "~> 2.0.1", ">= 1.0.0"
+  s.add_development_dependency "webmock", "~> 1.22", ">= 1.21.0"
 
   # Jar dependencies
   s.requirements << "jar 'org.elasticsearch:elasticsearch', '1.4.0'"
-  s.add_runtime_dependency "jar-dependencies", ">= 0.1.7"
+  s.add_runtime_dependency "jar-dependencies", "~> 0.2.2", ">= 0.1.7"
+
 end

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -19,21 +19,22 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  if java.lang.System.get_property('java.version') < "1.7"  # jdk6
-    s.add_runtime_dependency "logstash-core", "<= 2.0.0.snapshot3", ">= 1.4.0"
-  else
-    s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot3", ">= 1.4.0"
+
+  # logstash-core > 2.0.0.snapshot3 requires jrjackson ~> 0.3.5, which requires
+  # JDK7.
+  core_upper_bound = "~> 2.0.0.snapshot3"
+  if RUBY_PLATFORM == 'java'
+    s.platform        = RUBY_PLATFORM
+    if java.lang.System.get_property('java.version') < "1.7"   # JDK6
+      core_upper_bound = "<= 2.0.0.snapshot3"
+    end
   end
 
+  s.add_runtime_dependency "logstash-core", core_upper_bound, ">= 1.4.0"
   s.add_runtime_dependency "logstash-codec-plain", "~> 2.0.0", ">= 1.0.0"
   s.add_runtime_dependency "rest-client", '~> 1.8', ">= 1.8.0"
   s.add_development_dependency "logstash-devutils", "~> 0.0.16"
   s.add_development_dependency "logstash-filter-json", "~> 2.0.1", ">= 1.0.1"
   s.add_development_dependency "logstash-input-generator", "~> 2.0.1", ">= 1.0.0"
   s.add_development_dependency "webmock", "~> 1.22", ">= 1.21.0"
-
-  # Jar dependencies
-  s.requirements << "jar 'org.elasticsearch:elasticsearch', '1.4.0'"
-  s.add_runtime_dependency "jar-dependencies", "~> 0.2.2", ">= 0.1.7"
-
 end

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  if JRUBY_VERSION < "1.8"
+  if java.lang.System.get_property('java.version') < "1.7"  # jdk6
     s.add_runtime_dependency "logstash-core", "<= 2.0.0.snapshot3", ">= 1.4.0"
   else
     s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot3", ">= 1.4.0"

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -1,0 +1,1 @@
+require "logstash/devutils/rspec/spec_helper"

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -1,1 +1,100 @@
-require "logstash/devutils/rspec/spec_helper"
+require_relative "../spec_helper"
+
+describe LogStash::Outputs::Slack do
+
+  let(:short_config) do <<-CONFIG
+      input {
+        generator {
+          message => "This message should show in slack"
+          count => 1
+        }
+      }
+
+      output {
+        slack {
+          url => "http://requestb.in/r9lkbzr9"
+        }
+      }
+  CONFIG
+  end
+
+  let(:long_config) do <<-CONFIG
+      input {
+        generator {
+          message => "This message should show in slack"
+          add_field => {"extra" => 3}
+          count => 1
+        }
+      }
+
+      output {
+        slack {
+          url => "http://requestb.in/r9lkbzr9"
+          format => "%{message} %{extra}"
+          channel => "mychannel"
+          username => "slackbot"
+          icon_emoji => ":chart_with_upwards_trend:"
+          icon_url => "http://lorempixel.com/48/48"
+        }
+      }
+  CONFIG
+  end
+
+  before do
+    WebMock.disable_net_connect!
+  end
+
+  after do
+    WebMock.reset!
+    WebMock.allow_net_connect!
+  end
+
+  context "passes the right payload to slack" do
+    it "uses all default values" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      expected_json = {
+        :text => "This message should show in slack"
+      }
+
+      LogStash::Pipeline.new(short_config).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
+
+    it "uses all provided values" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      expected_json = {
+        :text => "This message should show in slack 3",
+        :channel => "mychannel",
+        :username => "slackbot",
+        :icon_emoji => ":chart_with_upwards_trend:",
+        :icon_url => "http://lorempixel.com/48/48"
+      }
+
+      LogStash::Pipeline.new(long_config).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
+
+  end
+end

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -22,7 +22,7 @@ describe LogStash::Outputs::Slack do
       input {
         generator {
           message => "This message should show in slack"
-          add_field => {"extra" => 3}
+          add_field => {"extra" => "3"}
           count => 1
         }
       }

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -2,67 +2,6 @@ require_relative "../spec_helper"
 
 describe LogStash::Outputs::Slack do
 
-  let(:short_config) do <<-CONFIG
-      input {
-        generator {
-          message => "This message should show in slack"
-          count => 1
-        }
-      }
-
-      output {
-        slack {
-          url => "http://requestb.in/r9lkbzr9"
-        }
-      }
-  CONFIG
-  end
-
-  let(:long_formatted_config) do <<-CONFIG
-      input {
-        generator {
-          message => "This message should show in slack"
-          add_field => {"x" => "3"
-                        "channelname" => "mychannel"
-                        "username" => "slackbot"}
-          count => 1
-        }
-      }
-
-      output {
-        slack {
-          url => "http://requestb.in/r9lkbzr9"
-          format => "%{message} %{x}"
-          channel => "%{channelname}"
-          username => "%{username}"
-          icon_emoji => ":chart_with_upwards_trend:"
-          icon_url => "http://lorempixel.com/48/48"
-        }
-      }
-  CONFIG
-  end
-
-  let(:long_unformatted_config) do <<-CONFIG
-      input {
-        generator {
-          message => "This message should not show in slack"
-          count => 1
-        }
-      }
-
-      output {
-        slack {
-          url => "http://requestb.in/r9lkbzr9"
-          format => "Unformatted message"
-          channel => "mychannel"
-          username => "slackbot"
-          icon_emoji => ":chart_with_upwards_trend:"
-          icon_url => "http://lorempixel.com/48/48"
-        }
-      }
-  CONFIG
-  end
-
   before do
     WebMock.disable_net_connect!
   end
@@ -82,7 +21,20 @@ describe LogStash::Outputs::Slack do
         :text => "This message should show in slack"
       }
 
-      LogStash::Pipeline.new(short_config).run
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+            }
+          }
+      CONFIG
+      ).run
 
       expect(a_request(:post, "http://requestb.in/r9lkbzr9").
         with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
@@ -107,7 +59,28 @@ describe LogStash::Outputs::Slack do
         :icon_url => "http://lorempixel.com/48/48"
       }
 
-      LogStash::Pipeline.new(long_formatted_config).run
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              add_field => {"x" => "3"
+                            "channelname" => "mychannel"
+                            "username" => "slackbot"}
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              format => "%{message} %{x}"
+              channel => "%{channelname}"
+              username => "%{username}"
+              icon_emoji => ":chart_with_upwards_trend:"
+              icon_url => "http://lorempixel.com/48/48"
+            }
+          }
+      CONFIG
+      ).run
 
       expect(a_request(:post, "http://requestb.in/r9lkbzr9").
         with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
@@ -132,7 +105,25 @@ describe LogStash::Outputs::Slack do
         :icon_url => "http://lorempixel.com/48/48"
       }
 
-      LogStash::Pipeline.new(long_unformatted_config).run
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              format => "Unformatted message"
+              channel => "mychannel"
+              username => "slackbot"
+              icon_emoji => ":chart_with_upwards_trend:"
+              icon_url => "http://lorempixel.com/48/48"
+            }
+          }
+      CONFIG
+      ).run
 
       expect(a_request(:post, "http://requestb.in/r9lkbzr9").
         with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -119,16 +119,12 @@ describe LogStash::Outputs::Slack do
     end
 
     it "uses the default attachments if none are in the event" do
-      stub_request(:post, "requestb.in").
-        to_return(:body => "", :status => 200,
-                  :headers => { 'Content-Length' => 0 })
-
       expected_json = {
         :text => "This message should show in slack",
         :attachments => [{:image_url => "http://example.com/image.png"}]
       }
 
-      LogStash::Pipeline.new(<<-CONFIG
+      logstash_config = <<-CONFIG
           input {
             generator {
               message => "This message should show in slack"
@@ -144,28 +140,16 @@ describe LogStash::Outputs::Slack do
             }
           }
       CONFIG
-      ).run
 
-      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
-        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
-             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept'=> 'application/json',
-                'User-Agent' => 'logstash-output-slack'
-                })).
-        to have_been_made.once
+      test_one_event(logstash_config, expected_json)
     end
 
     it "ignores empty default attachments" do
-      stub_request(:post, "requestb.in").
-        to_return(:body => "", :status => 200,
-                  :headers => { 'Content-Length' => 0 })
-
       expected_json = {
         :text => "This message should show in slack"
       }
 
-      LogStash::Pipeline.new(<<-CONFIG
+      logstash_config = <<-CONFIG
           input {
             generator {
               message => "This message should show in slack"
@@ -179,32 +163,18 @@ describe LogStash::Outputs::Slack do
             }
           }
       CONFIG
-      ).run
 
-      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
-        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
-             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept'=> 'application/json',
-                'User-Agent' => 'logstash-output-slack'
-                })).
-        to have_been_made.once
+      test_one_event(logstash_config, expected_json)
     end
 
     it "uses event attachments over default attachments" do
-      stub_request(:post, "requestb.in").
-        to_return(:body => "", :status => 200,
-                  :headers => { 'Content-Length' => 0 })
-
-      attachments =
-
       expected_json = {
         :text => "This message should show in slack",
         :attachments => [{:thumb_url => "http://other.com/thumb.png"}]
       }
 
-      # add_field only takes string values
-      LogStash::Pipeline.new(<<-CONFIG
+      # add_field only takes string values, so we'll have to mutate to JSON
+      logstash_config = <<-CONFIG
           input {
             generator {
               message => "This message should show in slack"
@@ -229,31 +199,17 @@ describe LogStash::Outputs::Slack do
             }
           }
       CONFIG
-      ).run
 
-      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
-        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
-             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept'=> 'application/json',
-                'User-Agent' => 'logstash-output-slack'
-                })).
-        to have_been_made.once
+      test_one_event(logstash_config, expected_json)
     end
 
     it "erases default attachments if event attachments empty" do
-      stub_request(:post, "requestb.in").
-        to_return(:body => "", :status => 200,
-                  :headers => { 'Content-Length' => 0 })
-
-      attachments =
-
       expected_json = {
         :text => "This message should show in slack"
       }
 
-      # add_field only takes string values
-      LogStash::Pipeline.new(<<-CONFIG
+      # add_field only takes string values, so we'll have to mutate to JSON
+      logstash_config = <<-CONFIG
           input {
             generator {
               message => "This message should show in slack"
@@ -276,32 +232,17 @@ describe LogStash::Outputs::Slack do
             }
           }
       CONFIG
-      ).run
 
-      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
-        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
-             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept'=> 'application/json',
-                'User-Agent' => 'logstash-output-slack'
-                })).
-        to have_been_made.once
+      test_one_event(logstash_config, expected_json)
     end
 
     it "ignores event attachment if not array" do
-      stub_request(:post, "requestb.in").
-        to_return(:body => "", :status => 200,
-                  :headers => { 'Content-Length' => 0 })
-
-      attachments =
-
       expected_json = {
         :text => "This message should show in slack",
         :attachments => [{:image_url => "http://example.com/image.png"}]
       }
 
-      # add_field only takes string values
-      LogStash::Pipeline.new(<<-CONFIG
+      logstash_config = <<-CONFIG
           input {
             generator {
               message => "This message should show in slack"
@@ -318,16 +259,8 @@ describe LogStash::Outputs::Slack do
             }
           }
       CONFIG
-      ).run
 
-      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
-        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
-             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept'=> 'application/json',
-                'User-Agent' => 'logstash-output-slack'
-                })).
-        to have_been_made.once
+      test_one_event(logstash_config, expected_json)
     end
   end
 end

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -117,5 +117,217 @@ describe LogStash::Outputs::Slack do
 
       test_one_event(logstash_config, expected_json)
     end
+
+    it "uses the default attachments if none are in the event" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      expected_json = {
+        :text => "This message should show in slack",
+        :attachments => [{:image_url => "http://example.com/image.png"}]
+      }
+
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => [
+                {image_url => "http://example.com/image.png"}
+              ]
+            }
+          }
+      CONFIG
+      ).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
+
+    it "ignores empty default attachments" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      expected_json = {
+        :text => "This message should show in slack"
+      }
+
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => []
+            }
+          }
+      CONFIG
+      ).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
+
+    it "uses event attachments over default attachments" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      attachments =
+
+      expected_json = {
+        :text => "This message should show in slack",
+        :attachments => [{:thumb_url => "http://other.com/thumb.png"}]
+      }
+
+      # add_field only takes string values
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+              add_field => {
+                attachments => '[{"thumb_url": "http://other.com/thumb.png"}]'
+              }
+            }
+          }
+          filter {
+            json {
+              source => "attachments"
+              target => "attachments"
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => [
+                {image_url => "http://example.com/image.png"}
+              ]
+            }
+          }
+      CONFIG
+      ).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
+
+    it "erases default attachments if event attachments empty" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      attachments =
+
+      expected_json = {
+        :text => "This message should show in slack"
+      }
+
+      # add_field only takes string values
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+              add_field => {attachments => '[]'}
+            }
+          }
+          filter {
+            json {
+              source => "attachments"
+              target => "attachments"
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => [
+                {image_url => "http://example.com/image.png"}
+              ]
+            }
+          }
+      CONFIG
+      ).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
+
+    it "ignores event attachment if not array" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      attachments =
+
+      expected_json = {
+        :text => "This message should show in slack",
+        :attachments => [{:image_url => "http://example.com/image.png"}]
+      }
+
+      # add_field only takes string values
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+              add_field => {attachments => "baddata"}
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => [
+                {image_url => "http://example.com/image.png"}
+              ]
+            }
+          }
+      CONFIG
+      ).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
   end
 end

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -144,6 +144,34 @@ describe LogStash::Outputs::Slack do
       test_one_event(logstash_config, expected_json)
     end
 
+    it "supports multiple default attachments" do
+      expected_json = {
+        :text => "This message should show in slack",
+        :attachments => [{:image_url => "http://example.com/image1.png"},
+                         {:image_url => "http://example.com/image2.png"}]
+      }
+
+      logstash_config = <<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => [
+                {image_url => "http://example.com/image1.png"},
+                {image_url => "http://example.com/image2.png"}
+              ]
+            }
+          }
+      CONFIG
+
+      test_one_event(logstash_config, expected_json)
+    end
+
     it "ignores empty default attachments" do
       expected_json = {
         :text => "This message should show in slack"
@@ -194,7 +222,8 @@ describe LogStash::Outputs::Slack do
             slack {
               url => "http://requestb.in/r9lkbzr9"
               attachments => [
-                {image_url => "http://example.com/image.png"}
+                {image_url => "http://example.com/image1.png"},
+                {image_url => "http://example.com/image2.png"}
               ]
             }
           }
@@ -227,7 +256,8 @@ describe LogStash::Outputs::Slack do
             slack {
               url => "http://requestb.in/r9lkbzr9"
               attachments => [
-                {image_url => "http://example.com/image.png"}
+                {image_url => "http://example.com/image1.png"},
+                {image_url => "http://example.com/image2.png"}
               ]
             }
           }

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -18,11 +18,13 @@ describe LogStash::Outputs::Slack do
   CONFIG
   end
 
-  let(:long_config) do <<-CONFIG
+  let(:long_formatted_config) do <<-CONFIG
       input {
         generator {
           message => "This message should show in slack"
-          add_field => {"extra" => "3"}
+          add_field => {"x" => "3"
+                        "channelname" => "mychannel"
+                        "username" => "slackbot"}
           count => 1
         }
       }
@@ -30,7 +32,28 @@ describe LogStash::Outputs::Slack do
       output {
         slack {
           url => "http://requestb.in/r9lkbzr9"
-          format => "%{message} %{extra}"
+          format => "%{message} %{x}"
+          channel => "%{channelname}"
+          username => "%{username}"
+          icon_emoji => ":chart_with_upwards_trend:"
+          icon_url => "http://lorempixel.com/48/48"
+        }
+      }
+  CONFIG
+  end
+
+  let(:long_unformatted_config) do <<-CONFIG
+      input {
+        generator {
+          message => "This message should not show in slack"
+          count => 1
+        }
+      }
+
+      output {
+        slack {
+          url => "http://requestb.in/r9lkbzr9"
+          format => "Unformatted message"
           channel => "mychannel"
           username => "slackbot"
           icon_emoji => ":chart_with_upwards_trend:"
@@ -71,7 +94,7 @@ describe LogStash::Outputs::Slack do
         to have_been_made.once
     end
 
-    it "uses all provided values" do
+    it "uses and formats all provided values" do
       stub_request(:post, "requestb.in").
         to_return(:body => "", :status => 200,
                   :headers => { 'Content-Length' => 0 })
@@ -84,7 +107,7 @@ describe LogStash::Outputs::Slack do
         :icon_url => "http://lorempixel.com/48/48"
       }
 
-      LogStash::Pipeline.new(long_config).run
+      LogStash::Pipeline.new(long_formatted_config).run
 
       expect(a_request(:post, "http://requestb.in/r9lkbzr9").
         with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
@@ -96,5 +119,29 @@ describe LogStash::Outputs::Slack do
         to have_been_made.once
     end
 
+    it "uses and formats all provided values" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      expected_json = {
+        :text => "Unformatted message",
+        :channel => "mychannel",
+        :username => "slackbot",
+        :icon_emoji => ":chart_with_upwards_trend:",
+        :icon_url => "http://lorempixel.com/48/48"
+      }
+
+      LogStash::Pipeline.new(long_unformatted_config).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/outputs/slack"
+require 'webmock/rspec'


### PR DESCRIPTION
Merged https://github.com/cyli/logstash-output-slack master branch in, and attempted to merge the two `README.md`'s.

The link to all asciidoc documentation in the bootstrap README seems to be broken.

Copied description from https://github.com/elastic/logstash/issues/3000:

I've attempted to create a new plugin as per [these instructions](http://www.elastic.co/guide/en/logstash/current/_how_to_write_a_logstash_output_plugin.html#_publishing_to_ulink_url_http_rubygems_org_rubygems_org_ulink_4) for pushing log messages to slack:

https://github.com/cyli/logstash-output-slack

I've manually tested this, but it doesn't really have fantastic rspec coverage (not sure how to test logging on errors, for instance), and would love a review (as I don't really know Ruby) + moving this to [logstash-plugins](https://github.com/logstash-plugins)  :)

This would supercede [this PR](https://github.com/elastic/logstash-contrib/pull/120).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/logstash-plugins/logstash-output-slack/1)

<!-- Reviewable:end -->
