### PR TITLE
Enable Interpolation in Attachments

### DIFF
--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -60,7 +60,7 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
     end
 
     if @attachments and @attachments.any?
-      payload_json['attachments'] = @attachments
+      payload_json['attachments'] = @attachments.map { |x| JSON.parse(event.sprintf(JSON.dump(x))) }
     end
     if event.include?('attachments') and event.get('attachments').is_a?(Array)
       if event.get('attachments').any?


### PR DESCRIPTION
This allows for interpolation in attachments defined via config file, e.g.

```
attachments => [
  {
    title => "Syslog Alert"
    text  => "This might be bad"
    fields => [
      {
        title => "Source"
        value => "%{MessageSourceAddress}"
        short => "false"
      },
      {
        title => "Message"
        value => "%{Message}"
        short => "false"
      }
    ]
    color  => "#FF8000"
    footer => ":heart: LogStash"
  }
]
```

