### PR TITLE
Read the environment http_proxy variable for the RestClient proxy

### DIFF
--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -75,6 +75,7 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
     end
 
     begin
+      RestClient.proxy = ENV['http_proxy']      
       RestClient.post(
         url,
         "payload=#{CGI.escape(JSON.dump(payload_json))}",


### PR DESCRIPTION
The systems proxy settings are not taken into account for rest-client, so an option is to specifically point to the proxy environment variable.
This change was already implemented in source repo from cyli, but slipped away during a transition to the logstash-plugins project.