### PR TITLE
Allow comma seperated channels

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -46,7 +46,7 @@ output plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-attachments"]
-===== `attachments` 
+===== `attachments`
 
   * Value type is <<array,array>>
   * There is no default value for this setting.
@@ -54,15 +54,16 @@ output plugins.
 Attachments array as described https://api.slack.com/docs/attachments
 
 [id="plugins-{type}s-{plugin}-channel"]
-===== `channel` 
+===== `channel`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
+  * Comma-seperated list of channels to message
 
 The channel to post to
 
 [id="plugins-{type}s-{plugin}-format"]
-===== `format` 
+===== `format`
 
   * Value type is <<string,string>>
   * Default value is `"%{message}"`
@@ -70,7 +71,7 @@ The channel to post to
 The text to post in slack
 
 [id="plugins-{type}s-{plugin}-icon_emoji"]
-===== `icon_emoji` 
+===== `icon_emoji`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -78,7 +79,7 @@ The text to post in slack
 Emoji icon to use
 
 [id="plugins-{type}s-{plugin}-icon_url"]
-===== `icon_url` 
+===== `icon_url`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -86,7 +87,7 @@ Emoji icon to use
 Icon URL to use
 
 [id="plugins-{type}s-{plugin}-url"]
-===== `url` 
+===== `url`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -95,7 +96,7 @@ Icon URL to use
 The incoming webhook URI needed to post a message
 
 [id="plugins-{type}s-{plugin}-username"]
-===== `username` 
+===== `username`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.


### PR DESCRIPTION
A simple change to allow multiple messages to be sent by iterating over channels by using a comma-separated string.
